### PR TITLE
Fix OpenAI service path

### DIFF
--- a/app/api/open-ai-chat-responses/route.ts
+++ b/app/api/open-ai-chat-responses/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createAssistantResponse } from '@/lib/openaiService';
+import { createAssistantResponse } from '@/lib/services/openai-responses-service';
 
 export async function POST(req: NextRequest) {
   try {


### PR DESCRIPTION
## Summary
- update OpenAI API service import path

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452bf914448323bfeb4644f8663861